### PR TITLE
Use MS5611_READ_OK in MS5611.read() error checking

### DIFF
--- a/examples/MS5611_test/MS5611_test.ino
+++ b/examples/MS5611_test/MS5611_test.ino
@@ -24,7 +24,7 @@ void setup()
 void loop()
 {
   int result = MS5611.read();
-  if (result != 0)
+  if (result != MS5611_READ_OK)
   {
     Serial.print("Error in read: ");
     Serial.println(result);


### PR DESCRIPTION
Since this constant is provided by the library for this exact purpose, it seems sensible to include it's usage in the examples.