### PR TITLE
Updated oversampling timings and information

### DIFF
--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -110,16 +110,16 @@ bool MS5611::isConnected()
 void MS5611::reset()
 {
   command(MS5611_CMD_RESET);
-  delay(3);
+  delayMicroseconds(2800);
   // constants that were multiplied in read()
   // do this once and you save CPU cycles
   C[0] = 1;
-  C[1] = 32768L;
-  C[2] = 65536L;
-  C[3] = 3.90625E-3;
-  C[4] = 7.8125E-3;
-  C[5] = 256;
-  C[6] = 1.1920928955E-7;
+  C[1] = 32768L;          // SENSt1 = C[1] * 2^15
+  C[2] = 65536L;          // OFFt1 = C[2] * 2^16
+  C[3] = 3.90625E-3;      // TCS = C[3] / 2^6
+  C[4] = 7.8125E-3;       // TCO = C[4] / 2^7
+  C[5] = 256;             // Tref = C[5] * 2^8
+  C[6] = 1.1920928955E-7; // TEMPSENS = C[6] / 2^23
   // read factory calibrations from EEPROM.
   for (uint8_t reg = 0; reg < 7; reg++)
   {

--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -7,7 +7,7 @@
 //     URL: https://github.com/RobTillaart/MS5611
 //
 //  HISTORY:
-//
+//  0.3.2.1 2021-12-25  Update oversampling timings to reduce time spent waiting
 //  0.3.2   2021-12-24  add get/set oversampling, read() (thanks to LyricPants66133)
 //  0.3.1   2021-12-21  update library.json, readme, license, minor edits
 //  0.3.0   2021-01-27  fix #9 math error (thanks to Emiel Steerneman)
@@ -197,12 +197,13 @@ void MS5611::setOversampling(osr_t samplingRate)
 //
 void MS5611::convert(const uint8_t addr, uint8_t bits)
 {
-  uint8_t del[5] = {1, 2, 3, 5, 10};
+  //Values from page 2 datasheet
+  uint16_t del[5] = {500, 1100, 2100, 4100, 8220};
 
   bits = constrain(bits, 8, 12);
   uint8_t offset = (bits - 8) * 2;
   command(addr + offset);
-  delay(del[offset/2]);
+  delayMicroseconds(del[offset/2]);
 }
 
 

--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -2,12 +2,12 @@
 //    FILE: MS5611.cpp
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-// VERSION: 0.3.2
+// VERSION: 0.3.3
 // PURPOSE: MS5611 Temperature & Humidity library for Arduino
 //     URL: https://github.com/RobTillaart/MS5611
 //
 //  HISTORY:
-//  0.3.2.1 2021-12-25  Update oversampling timings to reduce time spent waiting
+//  0.3.3   2021-12-25  Update oversampling timings to reduce time spent waiting
 //  0.3.2   2021-12-24  add get/set oversampling, read() (thanks to LyricPants66133)
 //  0.3.1   2021-12-21  update library.json, readme, license, minor edits
 //  0.3.0   2021-01-27  fix #9 math error (thanks to Emiel Steerneman)

--- a/MS5611.h
+++ b/MS5611.h
@@ -3,7 +3,7 @@
 //    FILE: MS5611.h
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-// VERSION: 0.3.2.1
+// VERSION: 0.3.3
 // PURPOSE: Arduino library for MS5611 temperature and pressure sensor
 //     URL: https://github.com/RobTillaart/MS5611
 
@@ -12,7 +12,7 @@
 #include "Wire.h"
 
 
-#define MS5611_LIB_VERSION                    (F("0.3.2"))
+#define MS5611_LIB_VERSION                    (F("0.3.3"))
 
 
 #define MS5611_READ_OK                        0

--- a/MS5611.h
+++ b/MS5611.h
@@ -3,7 +3,7 @@
 //    FILE: MS5611.h
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-// VERSION: 0.3.2
+// VERSION: 0.3.2.1
 // PURPOSE: Arduino library for MS5611 temperature and pressure sensor
 //     URL: https://github.com/RobTillaart/MS5611
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ See table below and test example how to use.
 
 #### Oversampling table
 
-| definition     | value | time (ms) | notes |
-|:---------------|:-----:|----------:|:------|
-| OSR_ULTRA_HIGH |  12   |  10       |
-| OSR_HIGH       |  11   |   5       |
-| OSR_STANDARD   |  10   |   3       |
-| OSR_LOW        |  9    |   2       |
-| OSR_ULTRA_LOW  |  8    |   1       | Default = backwards compatible
+| definition     | value | oversampling ratio | resolution (mbar) | time (ms) | notes |
+|:--------------:|:-----:|:------------------:|:----------------:|:---------:|:------:|
+| OSR_ULTRA_HIGH |  12   |        4096        |      0.012       |   8.22    |
+| OSR_HIGH       |  11   |        2048        |      0.018       |   4.1     |
+| OSR_STANDARD   |  10   |        1024        |      0.027       |   2.1     |
+| OSR_LOW        |  9    |        512         |      0.042       |   1.1     |
+| OSR_ULTRA_LOW  |  8    |        256         |      0.065       |   0.5     | Default = backwards compatible
 
 
 ## Disclaimer

--- a/examples/MS5611_test/MS5611_test.ino
+++ b/examples/MS5611_test/MS5611_test.ino
@@ -31,11 +31,11 @@ void setup()
   /*
   There are 5 oversampling settings, each corresponding to a different amount of milliseconds
   The higher the oversampling, the more accurate the reading will be, however the longer it will take.
-  OSR_ULTRA_HIGH -> 10 millis
-  OSR_HIGH       -> 5 millis
-  OSR_STANDARD   -> 3 millis
-  OSR_LOW        -> 2 millis
-  OSR_ULTRA_LOW  -> 1 millis   Default = backwards compatible
+  OSR_ULTRA_HIGH -> 8.22 millis
+  OSR_HIGH       -> 4.11 millis
+  OSR_STANDARD   -> 2.1 millis
+  OSR_LOW        -> 1.1 millis
+  OSR_ULTRA_LOW  -> 0.5 millis   Default = backwards compatible
   */
   MS5611.setOversampling(OSR_ULTRA_HIGH);
 }

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/MS5611.git"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MS5611
-version=0.3.2
+version=0.3.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for MS5611 temperature and pressure sensor


### PR DESCRIPTION
Updated version to 3.2.1
Updated reset and oversampling timings to be that of the datasheet to reduce time spent waiting
Added more information to Oversampling Datatable

It would also be nice to be able to create repo branches instead of having to fork.