### PR TITLE
Add SPI Support

### DIFF
--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -112,7 +112,7 @@ bool MS5611::begin(TwoWire * wire)
 #ifdef iSPI
 bool MS5611::begin(SPIClass * spi)
 {
-  _SPI = spi;
+  _SPI = SPI;
   _SPI->begin();
   if (! isConnected()) return false;
   

--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -2,11 +2,13 @@
 //    FILE: MS5611.cpp
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-// VERSION: 0.3.3
+//          Alfredo Colas(LyricPants66133)
+// VERSION: 0.4.0
 // PURPOSE: MS5611 Temperature & Humidity library for Arduino
 //     URL: https://github.com/RobTillaart/MS5611
 //
 //  HISTORY:
+//  0.4.0   2021-12-29  Add SPI Interface
 //  0.3.3   2021-12-25  Update oversampling timings to reduce time spent waiting
 //  0.3.2   2021-12-24  add get/set oversampling, read() (thanks to LyricPants66133)
 //  0.3.1   2021-12-21  update library.json, readme, license, minor edits
@@ -110,7 +112,7 @@ bool MS5611::begin(TwoWire * wire)
 
 
 #ifdef iSPI
-bool MS5611::begin(SPIClass * spi)
+bool MS5611::begin(SPIClass * SPI)
 {
   _SPI = SPI;
   _SPI->begin();
@@ -224,7 +226,7 @@ void MS5611::setOversampling(osr_t samplingRate)
 void MS5611::convert(const uint8_t addr, uint8_t bits) // Operational
 {
   //Values from page 2 datasheet
-  uint16_t del[5] = {500, 1100, 2100, 4100, 10000}; // do not stage
+  uint16_t del[5] = {500, 1100, 2100, 4100, 8220};
 
   bits = constrain(bits, 8, 12); //works //works
   uint8_t offset = (bits - 8) * 2;

--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -53,7 +53,7 @@
 //
 // PUBLIC - I2C
 //
-MS5611_I2C::MS5611_I2C(uint8_t deviceAddress)
+MS5611::MS5611(uint8_t deviceAddress)
 {
   _address      = deviceAddress;
   _samplingRate = OSR_ULTRA_LOW;
@@ -84,7 +84,7 @@ bool MS5611_I2C::begin(uint8_t dataPin, uint8_t clockPin, TwoWire * wire)
 #endif
 
 
-bool MS5611_I2C::begin(TwoWire * wire)
+bool MS5611::begin(TwoWire * wire)
 {
   if ((_address < 0x76) || (_address > 0x77)) return false;
   _wire = wire;
@@ -96,7 +96,7 @@ bool MS5611_I2C::begin(TwoWire * wire)
 }
 
 
-bool MS5611_I2C::isConnected() // Operational
+bool MS5611::isConnected() // Operational
 {
   _wire->beginTransmission(_address);
   _result = _wire->endTransmission();
@@ -231,7 +231,7 @@ void MS5611_base::setOversampling(osr_t samplingRate)
 //
 // PRIVATE - I2C
 //
-void MS5611_I2C::convert(const uint8_t addr, uint8_t bits)
+void MS5611::convert(const uint8_t addr, uint8_t bits)
 {
   //Values from page 2 datasheet
   uint16_t del[5] = {500, 1100, 2100, 4100, 8220};
@@ -243,7 +243,7 @@ void MS5611_I2C::convert(const uint8_t addr, uint8_t bits)
 }
 
 
-uint16_t MS5611_I2C::readProm(uint8_t reg)
+uint16_t MS5611::readProm(uint8_t reg)
 {
   // last EEPROM register is CRC - Page13 datasheet.
   uint8_t promCRCRegister = 7;
@@ -267,7 +267,7 @@ uint16_t MS5611_I2C::readProm(uint8_t reg)
 }
 
 
-uint32_t MS5611_I2C::readADC() // Operational
+uint32_t MS5611::readADC() // Operational
 {
   command(MS5611_CMD_READ_ADC);
   if (_result == 0)
@@ -287,7 +287,7 @@ uint32_t MS5611_I2C::readADC() // Operational
 
 
 // Consider adding seperate spi with a byte and delay argument
-int MS5611_I2C::command(const uint8_t command) //Operational
+int MS5611::command(const uint8_t command) //Operational
 {
   yield();
 

--- a/MS5611.cpp
+++ b/MS5611.cpp
@@ -96,7 +96,7 @@ bool MS5611::begin(TwoWire * wire)
 }
 
 
-bool MS5611::isConnected() // Operational
+bool MS5611::isConnected()
 {
   _wire->beginTransmission(_address);
   _result = _wire->endTransmission();
@@ -131,7 +131,7 @@ bool MS5611_SPI::begin(SPIClass * SPI)
 }
 
 
-bool MS5611_SPI::isConnected() // Operational
+bool MS5611_SPI::isConnected()
 {
   return (command(0x00) == MS5611_READ_OK); // 0X00 asks for a byte
 }
@@ -141,7 +141,7 @@ bool MS5611_SPI::isConnected() // Operational
 //
 // PUBLIC - base
 //
-void MS5611_base::reset() // Operational
+void MS5611_base::reset()
 {
   command(MS5611_CMD_RESET);
   delayMicroseconds(2800);
@@ -165,7 +165,7 @@ void MS5611_base::reset() // Operational
 }
 
 
-int MS5611_base::read(uint8_t bits) // operational
+int MS5611_base::read(uint8_t bits)
 {
   // VARIABLES NAMES BASED ON DATASHEET
   // ALL MAGIC NUMBERS ARE FROM DATASHEET
@@ -267,7 +267,7 @@ uint16_t MS5611::readProm(uint8_t reg)
 }
 
 
-uint32_t MS5611::readADC() // Operational
+uint32_t MS5611::readADC()
 {
   command(MS5611_CMD_READ_ADC);
   if (_result == 0)
@@ -286,8 +286,7 @@ uint32_t MS5611::readADC() // Operational
 }
 
 
-// Consider adding seperate spi with a byte and delay argument
-int MS5611::command(const uint8_t command) //Operational
+int MS5611::command(const uint8_t command)
 {
   yield();
 
@@ -342,7 +341,7 @@ uint16_t MS5611_SPI::readProm(uint8_t reg)
 }
 
 
-uint32_t MS5611_SPI::readADC() // Operational
+uint32_t MS5611_SPI::readADC()
 {
   _SPI->beginTransaction(_spiSettings);           // start SPI
   digitalWrite(_address, LOW);                    // select device
@@ -359,7 +358,7 @@ uint32_t MS5611_SPI::readADC() // Operational
 }
 
 
-int MS5611_SPI::command(const uint8_t command) //Operational
+int MS5611_SPI::command(const uint8_t command)
 {
   yield();
 

--- a/MS5611.h
+++ b/MS5611.h
@@ -1,4 +1,6 @@
 #pragma once
+// Can be set to I2C or SPI
+#define iSPI
 //
 //    FILE: MS5611.h
 //  AUTHOR: Rob Tillaart
@@ -9,13 +11,26 @@
 
 
 #include "Arduino.h"
+
+#ifdef iI2C
 #include "Wire.h"
+#endif
+
+#ifdef iSPI
+#include "SPI.h"
+#endif
 
 
 #define MS5611_LIB_VERSION                    (F("0.3.3"))
 
 
+#ifdef iI2C
 #define MS5611_READ_OK                        0
+#endif
+#ifdef iSPI
+#define MS5611_READ_OK                        254
+#endif
+
 #define MS5611_ERROR_2                        2         // low level I2C error
 #define MS5611_NOT_READ                       -999
 
@@ -33,12 +48,21 @@ enum osr_t
 class MS5611
 {
 public:
-  explicit MS5611(uint8_t deviceAddress);
-
 #if defined (ESP8266) || defined(ESP32)
   bool     begin(uint8_t sda, uint8_t scl, TwoWire *wire = &Wire);
 #endif
+
+//ensures that only one library needs to be included
+#ifdef iI2C
+  explicit MS5611(uint8_t deviceAddress);
   bool     begin(TwoWire *wire = &Wire);
+#endif
+
+#ifdef iSPI
+  explicit MS5611(uint8_t deviceAddress, SPISettings uspiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0)); // sensor does up to 20 MHZ, must be MSBFIRST, sensor supports mode0 and mode3
+  bool     begin(SPIClass *spi = &SPI);
+#endif
+
   bool     isConnected();
 
   // reset command + get constants
@@ -82,7 +106,14 @@ private:
   float    C[7];
   uint32_t _lastRead;
 
+  #ifdef iI2C
   TwoWire * _wire;
+  #endif
+  
+  #ifdef iSPI
+  SPIClass * _SPI;
+  SPISettings _spiSettings;
+  #endif
 };
 
 

--- a/MS5611.h
+++ b/MS5611.h
@@ -37,11 +37,11 @@
 
 enum osr_t
 {
-    OSR_ULTRA_HIGH = 12, // 10 millis
-    OSR_HIGH       = 11, //  5 millis
-    OSR_STANDARD   = 10, //  3 millis
-    OSR_LOW        = 9,  //  2 millis
-    OSR_ULTRA_LOW  = 8   //  1 millis    Default = backwards compatible
+    OSR_ULTRA_HIGH = 12, // 8.22 millis
+    OSR_HIGH       = 11, //  4.1 millis
+    OSR_STANDARD   = 10, //  2.1 millis
+    OSR_LOW        = 9,  //  1.1 millis
+    OSR_ULTRA_LOW  = 8   //  0.5 millis    Default = backwards compatible
 };
 
 

--- a/MS5611.h
+++ b/MS5611.h
@@ -30,14 +30,6 @@
 #define MS5611_CMD_CONVERT_D1     0x40
 #define MS5611_CMD_CONVERT_D2     0x50
 
-
-// enum MS5611_protocol
-// {
-//   MS5611_I2C,
-//   MS5611_SPI
-// };
-
-
 enum osr_t
 {
     OSR_ULTRA_HIGH = 12, // 8.22 millis

--- a/MS5611.h
+++ b/MS5611.h
@@ -1,11 +1,11 @@
 #pragma once
-// Can be set to I2C or SPI
+// Can be set to iI2C or iSPI
 #define iI2C
 //
 //    FILE: MS5611.h
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-//          Alfredo Colas - Oversampling fixes / SPI support
+//          Alfredo Colas(LyricPants66133)
 // VERSION: 0.4.0
 // PURPOSE: Arduino library for MS5611 temperature and pressure sensor
 //     URL: https://github.com/RobTillaart/MS5611
@@ -55,7 +55,7 @@ public:
 
 #ifdef iSPI
   explicit MS5611(uint8_t deviceAddress, SPISettings uspiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0)); // sensor does up to 20 MHZ, must be MSBFIRST, sensor supports mode0 and mode3
-  bool     begin(SPIClass *spi = &SPI);
+  bool     begin(SPIClass *SPI = &SPI);
 #endif
 
   bool     isConnected();

--- a/MS5611.h
+++ b/MS5611.h
@@ -1,11 +1,12 @@
 #pragma once
 // Can be set to I2C or SPI
-#define iSPI
+#define iI2C
 //
 //    FILE: MS5611.h
 //  AUTHOR: Rob Tillaart
 //          Erni - testing/fixes
-// VERSION: 0.3.3
+//          Alfredo Colas - Oversampling fixes / SPI support
+// VERSION: 0.4.0
 // PURPOSE: Arduino library for MS5611 temperature and pressure sensor
 //     URL: https://github.com/RobTillaart/MS5611
 
@@ -21,16 +22,10 @@
 #endif
 
 
-#define MS5611_LIB_VERSION                    (F("0.3.3"))
+#define MS5611_LIB_VERSION                    (F("0.4.0"))
 
 
-#ifdef iI2C
 #define MS5611_READ_OK                        0
-#endif
-#ifdef iSPI
-#define MS5611_READ_OK                        254
-#endif
-
 #define MS5611_ERROR_2                        2         // low level I2C error
 #define MS5611_NOT_READ                       -999
 

--- a/MS5611.h
+++ b/MS5611.h
@@ -103,10 +103,10 @@ private:
 
 
 
-class MS5611_I2C : public MS5611_base
+class MS5611 : public MS5611_base
 {
 public:
-  explicit MS5611_I2C(uint8_t deviceAddress);
+  explicit MS5611(uint8_t deviceAddress);
   bool     begin(TwoWire *wire = &Wire);
   bool     isConnected();
 

--- a/README.md
+++ b/README.md
@@ -5,32 +5,40 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/RobTillaart/MS5611/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/RobTillaart/MS5611.svg?maxAge=3600)](https://github.com/RobTillaart/MS5611/releases)
 
-
 # MS5611
 
 Arduino library for MS5611 temperature and pressure sensor.
-
 
 ## Description
 
 The MS5611 is a high resolution temperature and pressure sensor.
 The high resolution is made possible by oversampling (many times).
 
-The device address is 0x76 or 0x77 depending on the CSB pin.
+This library can communicate through I2C or SPI.
 
+When using I2C, the device address is 0x76 or 0x77 depending on the CSB pin.
 
-#### 0.3.0 breaking changes
+When using SPI, the chip select pin will work on any available digital pin.
+
+## Changelog
+
+### 0.4.0 changes
+
+1. added SPI support - default communication is through I2C
+
+### 0.3.0 breaking changes
 
 1. fixed math error so previous versions are **obsolete**.
 2. temperature is a float expressed in degrees Celsius.
 3. pressure is a float expressed in mBar.
 
-
 ## Interface
 
-- **MS5611(uint8_t deviceAddress)** constructor.
-- **bool begin(uint8_t sda, uint8_t scl, TwoWire \*wire = &Wire)** for ESP and alike, optionally set Wire interface. initializes internals, 
+- **MS5611(uint8_t deviceAddress)** constructor when using I2C
+- **MS5611(uint8_t deviceAddress, SPISettings uspiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0))** constructor when using SPI.
+- **bool begin(uint8_t sda, uint8_t scl, TwoWire \*wire = &Wire)** for ESP and alike, optionally set Wire interface. initializes internals.
 - **bool begin(TwoWire \*wire = &Wire)** for UNO and alike, optionally set Wire interface. Initializes internals.
+- **bool begin(SPIClass \*SPI = &SPI)** for UNO and alike, optionally set SPI interface. Initializes internals.
 - **bool isConnected()** checks availability of device address on the I2C bus.
 - **reset()** resets the chip and loads constants from its ROM.
 - **int read(uint8_t bits)** the actual reading of the sensor. Returns MS5611_READ_OK upon success.
@@ -40,11 +48,10 @@ See table below and test example how to use.
 - **osr_t getOversampling()** returns amount of oversampling.
 - **float getTemperature()** returns temperature in °C. Subsequent calls will return same value until a new **read()** is called.
 - **float getPressure()** pressure is in mBar. Subsequent calls will return same value until a new **read()** is called.
-- **int getLastResult()** checks last I2C communication (replace with more informative error handling?)
+- **int getLastResult()** checks last communication with device (replace with more informative error handling?).
 - **uint32_t lastRead()** last time when **read()** was called in millis() since startup.
 
-
-#### Oversampling table
+### Oversampling table
 
 | definition     | value | oversampling ratio | resolution (mbar) | time (ms) | notes |
 |:--------------:|:-----:|:------------------:|:----------------:|:---------:|:------:|
@@ -54,23 +61,19 @@ See table below and test example how to use.
 | OSR_LOW        |  9    |        512         |      0.042       |   1.1     |
 | OSR_ULTRA_LOW  |  8    |        256         |      0.065       |   0.5     | Default = backwards compatible
 
-
 ## Disclaimer
 
 The library is experimental. As I have no such sensor the quality is hard to test.
 So if you happen to have such a sensor, please give it a try and let me know.
 
-
 ## Operation
 
 See examples
-
 
 ## Future
 
 - get such a sensor to test
 - update documentation
-- create a SPI based library (same base class if possible?)
 - proper error handling
 - redo lower level functions?
 - handle the read + math of temperature first? (need hardware to test)

--- a/examples/MS5611_SPI_demo/MS5611_SPI_demo.ino
+++ b/examples/MS5611_SPI_demo/MS5611_SPI_demo.ino
@@ -1,0 +1,50 @@
+//
+//    FILE: MS5611_minimal.ino
+//  AUTHOR: Alfredo Colas
+// PURPOSE: demo application
+//    DATE: 2021-12-29
+//     URL: https://github.com/RobTillaart/MS5611
+
+
+#include "MS5611.h"
+
+// To be able to use SPI interface, `#define iI2C` at the top of the MS5611.h file *must* be changed to `#define iSPI`
+// first argument is the digital pin Chip Select is connected to
+// Second argument is optoinal. Do not include it unless you know what you are doing.
+// It defines SPI communiction settings. see https://www.arduino.cc/en/Reference/SPISettings for more info
+// irst argument must NOT exceed 2000000. Second aregument can only be MSBFIRST. Third argument can only be SPI_MODE0 and SPI_MODE3
+MS5611 MS5611(10, SPISettings(2000000, MSBFIRST, SPI_MODE0));
+// The rest of the library operates exactly the same as with I2C communication.
+
+
+void setup()
+{
+  Serial.begin(115200);
+  Serial.print(__FILE__);
+  Serial.print("MS5611_LIB_VERSION: ");
+  Serial.println(MS5611_LIB_VERSION);
+
+  if (MS5611.begin() == true)
+  {
+    Serial.println("MS5611 found.");
+  }
+  else
+  {
+    Serial.println("MS5611 not found. halt.");
+    while(1);
+  }
+}
+
+
+void loop()
+{
+  MS5611.read();           // note no error checking => "optimistic".
+  Serial.print("\nT:\t");
+  Serial.print(MS5611.getTemperature(), 2);
+  Serial.print("\tP:\t");
+  Serial.print(MS5611.getPressure(), 2);
+  delay(1000);
+}
+
+
+// -- END OF FILE --

--- a/examples/MS5611_SPI_demo/MS5611_SPI_demo.ino
+++ b/examples/MS5611_SPI_demo/MS5611_SPI_demo.ino
@@ -13,7 +13,7 @@
 // Second argument is optoinal. Do not include it unless you know what you are doing.
 // It defines SPI communiction settings. see https://www.arduino.cc/en/Reference/SPISettings for more info
 // irst argument must NOT exceed 2000000. Second aregument can only be MSBFIRST. Third argument can only be SPI_MODE0 and SPI_MODE3
-MS5611 MS5611(10, SPISettings(2000000, MSBFIRST, SPI_MODE0));
+MS5611_SPI MS5611(10, SPISettings(2000000, MSBFIRST, SPI_MODE0));
 // The rest of the library operates exactly the same as with I2C communication.
 
 

--- a/library.json
+++ b/library.json
@@ -12,13 +12,16 @@
     {
       "name": "Erni"
     }
+    {
+      "name": "Alfredo Colas"
+    }
   ],
   "repository":
   {
     "type": "git",
     "url": "https://github.com/RobTillaart/MS5611.git"
   },
-  "version": "0.3.3",
+  "version": "0.4.0",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "Erni"
-    }
+    },
     {
       "name": "Alfredo Colas"
     }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MS5611
-version=0.3.3
+version=0.4.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for MS5611 temperature and pressure sensor


### PR DESCRIPTION
(NOT READY FOR MERGE)

Added SPI support with minimal work required to use SPI. It uses all of the exact same function calls, with the exception of a minor change in the constructor for SPI.

Using preprocessors, the compiler only needs to import the required library for a communications protocol. This ensures that the other protocol is not redundantly included. This however does make the code *a bit* messier, but that can always be improved. To change protocols, the user must go into the header file and change a definition. I2C is the default protocol, so this should affect a minimal amount of users that need SPI.

As mentioned earlier, this code is not ready for merge. There is an odd issue with the SPI interface where the temperature readings are off by about +10C and increase rapidly. Pressure readings remain accurate. This issue should be fixed before a merge. I would also like to improve and clean up the code a bit more as well, but that is not currently essential.
